### PR TITLE
fix: 모달 오버레이 추가

### DIFF
--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -3,33 +3,33 @@
 import { useRef } from 'react';
 // import Portal from '@/components/Modal/Portalmodal';
 
-type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | 'full';
-
 // 모달 사이즈를 따로 잡고 싶은데, className으로 직접 작성해야 할 지, 상수로 빼서 관리할 지 고민
 
 interface BaseModalProps {
   isOpen: boolean;
   onClose: () => void;
   children: React.ReactNode;
-  size?: ModalSize;
   className?: string;
   title?: React.ReactNode;
+  closeOnOverlay?: boolean; // 추가
+  closeOnEsc?: boolean; // 추가
 }
 
 export default function BaseModal({
   isOpen,
   onClose,
   children,
-  size = 'md',
   className,
   title,
+  closeOnOverlay = true, // 기본값
+  closeOnEsc = true, // 얘도 추가해보고 싶은데 어떻게 쓸 수 있을까?(고민)
 }: BaseModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
   const handleOverLayClick = (e: React.MouseEvent) => {
-    if (e.target === overlayRef.current) {
-      onClose();
-    }
+    if (!closeOnOverlay) return;
+    if (e.target === overlayRef.current) onClose();
   };
+
   if (!isOpen) {
     return null;
   }
@@ -39,7 +39,7 @@ export default function BaseModal({
     <div
       ref={overlayRef}
       className="fixed inset-0 z-50 grid place-items-center bg-black/50 p-4"
-      aria-label="모달 오버레이: 클릭하면 닫힘"
+      aria-label="모달 오버레이"
       onClick={handleOverLayClick}
     >
       {/* 디테일 잡기? */}
@@ -52,6 +52,7 @@ export default function BaseModal({
           'max-h-[90vh] overflow-auto w-[540px]', // 스크롤 되도록 설정
           className ?? '',
         ].join(' ')}
+        onClick={(e) => e.stopPropagation()}
       >
         {title && (
           <div className="flex items-center justify-between px-6 py-4">

--- a/src/components/Modal/ConfirmModal.tsx
+++ b/src/components/Modal/ConfirmModal.tsx
@@ -4,15 +4,12 @@ import '@/styles/global.css';
 import BaseModal from '@/components/Modal/BaseModal';
 import Button from '@/playground/deprecated/Button/Button';
 
-type ModalSize = 'md' | 'lg' | 'xl';
-
 interface ConfirmModalProps {
   isOpen: boolean;
   onClose: () => void;
   message: string;
   onConfirm?: () => void; // 없으면 ‘확인’이 그냥 onClose
   confirmLabel?: string; // 확인
-  size?: ModalSize;
   className?: string;
 }
 
@@ -22,16 +19,10 @@ export default function ConfirmModal({
   message,
   onConfirm,
   confirmLabel = '확인',
-  size = 'lg',
   className,
 }: ConfirmModalProps) {
   return (
-    <BaseModal
-      isOpen={isOpen}
-      onClose={onClose}
-      size={size}
-      className={className}
-    >
+    <BaseModal isOpen={isOpen} onClose={onClose} className={className}>
       <div className="p-8">
         <p className="pt-14 text-center text-black">{message}</p>
         <div className="mt-8 flex justify-end gap-2">

--- a/src/components/Profile/ProfileCard.tsx
+++ b/src/components/Profile/ProfileCard.tsx
@@ -6,9 +6,8 @@ import { usePathname } from 'next/navigation';
 
 export default function ProfileCard() {
   const pathname = usePathname();
-  // next.js의 App Router에서 현재 URL의 경로(path) 부분을 읽어오는 클라이언트 컴포넌트 훅이라고 하는데, 이건 다른 페이지가 생성되면 연결하면 되는걸지?
+  // next.js의 App Router에서 현재 URL의 경로(path) 부분을 읽어오는 클라이언트 컴포넌트 훅이라고 하는데, 이건 다른 페이지가 생성되면 연결하면 되는걸지? --> 확인 완료
 
-  // 경로 설정의 이름을 확인해야 할 듯 !
   const MENU = [
     {
       key: 'info',
@@ -27,7 +26,7 @@ export default function ProfileCard() {
     {
       key: 'manage',
       label: '내 체험 관리',
-      href: '/Profile/Experience',
+      href: '/Profile/ExperienceSet',
       icon: '/icon/setting.svg',
       active: false,
     },


### PR DESCRIPTION
## PR 개요

- 모달 오버레이 추가

## 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링

## 상세 설명

모달 오버레이 추가 

```
interface BaseModalProps {
  isOpen: boolean;
  onClose: () => void;
  children: React.ReactNode;
  className?: string;
  title?: React.ReactNode;
  closeOnOverlay?: boolean; // 추가
  closeOnEsc?: boolean; // 추가
}
```

```
export default function BaseModal({
  isOpen,
  onClose,
  children,
  className,
  title,
  closeOnOverlay = true, // 기본값
  closeOnEsc = true, // 얘도 추가해보고 싶은데 어떻게 쓸 수 있을까?(고민)
}: BaseModalProps) {
  const overlayRef = useRef<HTMLDivElement>(null);
  const handleOverLayClick = (e: React.MouseEvent) => {
    if (!closeOnOverlay) return;
    if (e.target === overlayRef.current) onClose();
  };
```

## 관련 이슈

- closes #이슈번호

## Attachment

- 참고할 자료 첨부
