### PR TITLE
feat: 카테고리 선택 버튼 추가

### DIFF
--- a/public/icon/btn/down_arrow.svg
+++ b/public/icon/btn/down_arrow.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="9" viewBox="0 0 16 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.25 1L8 7.75L14.75 1" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/Profile/ReservationStatus/_components/ExperienceSelect.tsx
+++ b/src/app/Profile/ReservationStatus/_components/ExperienceSelect.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import Image from 'next/image';
+
+// 이건 유저가 선택을 해야 하는 컴포넌트라서 prop으로 타이틀만 받으면 안될 듯, prop으로 다 받아야 선택이 가능함 (선택된 항목, 여러 항목 등?)
+interface ExperienceSelectProps {
+  experiences: string[];
+  selectedExperience: string;
+  onSelectExperience: (experience: string) => void;
+  label?: string;
+  //   title: string;
+}
+
+export default function ExperienceSelect({
+  experiences,
+  selectedExperience,
+  onSelectExperience,
+  label = '체험명',
+}: ExperienceSelectProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="flex flex-col w-full mb-6 relative">
+      {/* 라벨이 보더 사이? 위? 에 위치해야 함 */}
+      <label
+        className="
+          absolute -top-2 left-3
+          px-1 text-sm font-medium text-[var(--color-gray-800)]
+          bg-white
+        "
+      >
+        {label}
+      </label>
+
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full rounded-md border px-4 py-4 text-left border-[var(--color-gray-800)] bg-white text-[var(--color-gray-800)] flex items-center justify-between"
+      >
+        <span className="truncate">{selectedExperience || '체험명 선택'}</span>
+        <Image
+          src="/icon/btn/down_arrow.svg"
+          alt="펼치기"
+          width={16}
+          height={16}
+          className="cousor-pointer"
+        />
+      </button>
+
+      {/* 리스트를 버튼 아래로 내리고 싶음 */}
+      {open && (
+        <ul
+          className="absolute top-full left-0 mt-1 w-full z-50
+            max-h-64 overflow-auto rounded-md border border-gray-200
+            bg-white shadow-lg"
+        >
+          {experiences.length === 0 && (
+            <li className="px-4 py-3 text-[var(--color-gray-600)]">
+              체험명이 없습니다.
+            </li>
+          )}
+          {experiences.map((exp) => (
+            <li key={exp}>
+              <button
+                type="button"
+                onClick={() => {
+                  onSelectExperience(exp);
+                  setOpen(false);
+                }}
+                className={`
+                  w-full text-left px-4 py-3 border-b-[var(--color-gray-800)]
+                  hover:bg-[var(--color-green-light)] hover:text-black
+                  ${exp === selectedExperience ? 'bg-[var(--color-gray-200)]' : ''}
+                `}
+                role="option"
+                aria-selected={exp === selectedExperience} // 접근성을 위함 (자동 생성되어 확인해봄)
+              >
+                {exp}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* select를 쓰게 되면 커스텀이 안되는 듯 */}
+      {/* <select
+        value={selectedExperience}
+        onChange={(e) => onSelectExperience(e.target.value)}
+        className="border border-[var(--color-gray-800)] rounded-sm px-4 py-4 text-[var(--color-gray-800)] bg-white "
+      >
+        {experiences.map((exp) => (
+          <option key={exp} value={exp}>
+            {exp}
+          </option>
+        ))}
+      </select> */}
+    </div>
+  );
+}

--- a/src/app/Profile/ReservationStatus/_components/ReservationCalendar.tsx
+++ b/src/app/Profile/ReservationStatus/_components/ReservationCalendar.tsx
@@ -6,7 +6,7 @@ import 'react-big-calendar/lib/css/react-big-calendar.css';
 import { Calendar, Views } from 'react-big-calendar';
 import { useMemo, useState } from 'react';
 import { localizer } from '@/lib/calendarLocalizer';
-import type { CalEvent, CalStatus } from '@/types/calendar';
+import type { CalEvent, ReservationStatus } from '@/types/calendar';
 import { mockCalEvents } from '@/app/Profile/ReservationStatus/mock/CalendarMockdata';
 import PendingModal from '@/components/Modal/ReservationModal/PendingModal';
 import ConfirmedModal from '@/components/Modal/ReservationModal/ConfirmedModal';
@@ -50,9 +50,14 @@ function EventBar() {
 export default function ReservationCalendar() {
   const [openModal, setOpenModal] = useState(false);
   const [selected, setSelected] = useState<CalEvent | null>(null);
-  const [reservationsForDate, setReservationsForDate] = useState<CalEvent[]>(
-    []
-  );
+  // 모달에 전달할 데이터의 타입을 명확하게 지정합니다.  --> 버그가 나서 확인 중인데 왜 이렇게 해야함? (공부중)
+  const [reservationsForDate, setReservationsForDate] = useState<
+    {
+      nickname: string;
+      people: number;
+      status: ReservationStatus;
+    }[]
+  >([]);
 
   const handleEventClick = (ev: CalEvent) => {
     setSelected(ev);
@@ -63,8 +68,11 @@ export default function ReservationCalendar() {
       (event) => event.start.toDateString() === clickedDate
     );
     setReservationsForDate(
-      // CalEvent[] 타입을 { nickname, people, status }[] 타입으로 변환 --> 이건 해석이 필요할 듯
-      dailyReservations.map((e) => ({ ...e, people: 1 }))
+      dailyReservations.map((e) => ({
+        ...e,
+        nickname: e.nickname || '',
+        people: e.people || 0, // people이 없으면 0을 기본값으로 사용
+      }))
     );
     setOpenModal(true);
   };
@@ -75,9 +83,13 @@ export default function ReservationCalendar() {
   };
 
   // API 연동으로 받을 항목! async 어쩌고 ..
-  const handleApprove = () => {};
+  const handleApprove = (nickname: string) => {
+    console.log(`${nickname}님 예약 승인`);
+  };
 
-  const handleReject = () => {};
+  const handleReject = (nickname: string) => {
+    console.log(`${nickname}님 예약 거절`);
+  };
 
   const formats = useMemo(
     () => ({
@@ -122,6 +134,7 @@ export default function ReservationCalendar() {
         }}
       />
 
+      {/* 모달 조립해보기 (신청, 승인, 거절) - 전달해야하는 Props와 Type들이 어렵군, 타입때문에 오류가 나는 듯 ㅠ*/}
       {openModal && selected && (
         <>
           {selected.status === 'pending' && (
@@ -153,40 +166,11 @@ export default function ReservationCalendar() {
               isOpen={openModal}
               onClose={handleCloseModal}
               status={selected.status}
-              // date={formatDate(selected.start)}
-              // time={formatTimeRange(selected.start, selected.end)}
               reservations={reservationsForDate}
             />
           )}
         </>
       )}
-
-      {/* 10/09 상태에 따른 모달을 따로 작업했으니, 여기서 각각 상태에 맞게 불러야 할 듯 -- 우선 주석처리 */}
-      {/* <BaseModal
-        isOpen={openModal}
-        onClose={() => {
-          setOpenModal(false);
-          setSelected(null);
-        }}
-        size="md"
-        title="예약 정보"
-        className="bg-white"
-      > */}
-      {/* status에 따라 보여지는 모달을 다르게 설정하기! 
-        그러면 굳이 BaseModal을 여기서 import 하지 않아도 될 수도 ? 근데 각 컴포넌트에서는 매번 import 해야하는데 뭐가 더 효율적인지 고민 필요할 듯 */}
-      {/* {selected && (
-          <div>
-            <p className="text-sm text-gray-600">
-              {selected.start.toLocaleString()} ~{' '}
-              {selected.end.toLocaleString()}
-            </p>
-            {selected.place && (
-              <p className="mt-1 text-sm">장소: {selected.place}</p>
-            )}
-            <p className="mt-1 text-sm">상태: {selected.status}</p>
-          </div>
-        )}
-      </BaseModal> */}
     </>
   );
 }

--- a/src/app/Profile/ReservationStatus/mock/CalendarMockdata.ts
+++ b/src/app/Profile/ReservationStatus/mock/CalendarMockdata.ts
@@ -8,6 +8,7 @@ export interface CalEvent {
   time?: string;
   place?: string;
   nickname?: string;
+  people?: number;
   status: CalStatus;
 }
 
@@ -20,6 +21,7 @@ export const mockCalEvents: CalEvent[] = [
     time: '2025-11-10 10:00~12:00',
     place: '홍대 스튜디오',
     nickname: '짱구',
+    people: 2,
     status: 'pending',
   },
   {
@@ -29,6 +31,7 @@ export const mockCalEvents: CalEvent[] = [
     end: new Date(2025, 9, 16, 14),
     place: '성수',
     nickname: '짱아',
+    people: 1,
     status: 'confirmed',
   },
   {
@@ -38,6 +41,7 @@ export const mockCalEvents: CalEvent[] = [
     end: new Date(2025, 9, 15, 12),
     place: '잠실',
     nickname: '흰둥이',
+    people: 3,
     status: 'canceled',
   },
   {
@@ -48,6 +52,7 @@ export const mockCalEvents: CalEvent[] = [
     time: '2025-11-10 10:00~12:00',
     place: '홍대 스튜디오',
     nickname: '신봉선',
+    people: 4,
     status: 'confirmed',
   },
 ];

--- a/src/app/Profile/ReservationStatus/page.tsx
+++ b/src/app/Profile/ReservationStatus/page.tsx
@@ -5,9 +5,15 @@ import ReservationCalendar from './_components/ReservationCalendar';
 import Header from '@/app/Profile/_components/MypageHeader/MypageHeader';
 import AlertModal from '@/components/Modal/AlertModal';
 import { mockAlerts } from '@/app/Profile/ReservationStatus/mock/AlertMockdata';
+import { mockCalEvents } from '@/app/Profile/ReservationStatus/mock/CalendarMockdata';
+import ExperienceSelect from '@/app/Profile/ReservationStatus/_components/ExperienceSelect';
 
 export default function ReservationStatusPage() {
+  const experiences = Array.from(new Set(mockCalEvents.map((ev) => ev.title)));
   const [isAlertOpen, setIsAlertOpen] = useState(true); // 테스트를 위해 true로 설정 (임시) 추후엔 흠 ..
+  const [selectedExperience, setSelectedExperience] = useState<string>(
+    experiences[0] || ''
+  );
 
   return (
     <div className="mx-auto max-w-screen-xl ">
@@ -20,9 +26,14 @@ export default function ReservationStatusPage() {
       {/* 공통 컴포넌트 적용 - title 유선님 작업하신 거 조립 완료 */}
       <Header title="예약 현황" />
       {/* 카테고리 필터 공통 컴포넌트 적용 필요 */}
-      <div>
+      <ExperienceSelect
+        experiences={experiences}
+        selectedExperience={selectedExperience}
+        onSelectExperience={setSelectedExperience}
+      />
+      {/* <div>
         <input placeholder="카테고리 선택" className="border" />
-      </div>
+      </div> */}
       <div className="h-[560px] md:h-[620px] lg:h-[680px]">
         <ReservationCalendar />
       </div>

--- a/src/components/Modal/ReservationModal/ConfirmedModal.tsx
+++ b/src/components/Modal/ReservationModal/ConfirmedModal.tsx
@@ -2,15 +2,19 @@
 
 import ReservationModalBase from './ReservationModalBase';
 import Chips from '@/components/chips/Chips';
-import type { CalStatus } from '@/types/calendar';
+import type { ReservationStatus } from '@/types/calendar';
 
 interface ConfirmModalProps {
   isOpen: boolean;
   onClose: () => void;
   date: string;
   time: string;
-  reservations: { nickname: string; people: number; status: CalStatus }[];
-  status: CalStatus;
+  reservations: {
+    nickname: string;
+    people: number;
+    status: ReservationStatus;
+  }[];
+  status: ReservationStatus;
 }
 
 export default function ConfirmModal({

--- a/src/components/Modal/ReservationModal/PendingModal.tsx
+++ b/src/components/Modal/ReservationModal/PendingModal.tsx
@@ -2,17 +2,17 @@
 
 import ReservationModalBase from './ReservationModalBase';
 import Button from '@/components/Button/Button';
-import type { CalStatus } from '@/types/calendar';
+import type { CalEvent, ReservationStatus } from '@/types/calendar';
 
 interface PendingModalProps {
   isOpen: boolean;
   onClose: () => void;
   date: string;
   time: string;
-  reservations: { nickname: string; people: number; status: CalStatus }[];
+  reservations: (CalEvent & { people: number })[];
   onApprove: (nickname: string) => void;
   onReject: (nickname: string) => void;
-  status: CalStatus;
+  status: ReservationStatus;
 }
 
 export default function PendingModal({
@@ -32,7 +32,11 @@ export default function PendingModal({
       status={status}
       date={date}
       time={time}
-      reservations={reservations}
+      reservations={reservations.map((item) => ({
+        nickname: item.nickname || '',
+        people: item.people,
+        status: item.status,
+      }))}
       renderActionButtons={(item) => (
         <div className="flex space-x-2">
           {/* 버튼 스타일이 왜 안 먹을까? */}

--- a/src/components/Modal/ReservationModal/ReservationModalBase.tsx
+++ b/src/components/Modal/ReservationModal/ReservationModalBase.tsx
@@ -3,18 +3,18 @@
 import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
 import BaseModal from '@/components/Modal/BaseModal';
-import type { CalStatus } from '@/types/calendar';
+import type { ReservationStatus } from '@/types/calendar';
 
 interface ReservationModalBaseProps {
   isOpen: boolean;
   onClose: () => void;
-  status: CalStatus;
+  status: ReservationStatus;
   date: string;
   time: string;
   reservations: {
     nickname: string;
     people: number;
-    status: CalStatus;
+    status: ReservationStatus;
   }[];
   renderActionButtons?: (item: {
     nickname: string;
@@ -31,7 +31,7 @@ export default function ReservationModalBase({
   reservations,
   renderActionButtons,
 }: ReservationModalBaseProps) {
-  const [activeTab, setActiveTab] = useState<CalStatus>(status);
+  const [activeTab, setActiveTab] = useState<ReservationStatus>(status);
 
   // 모달이 열릴 때마다 바꿔줘야 함
   useEffect(() => {

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -5,6 +5,8 @@ export type CalEvent = {
   title: string;
   start: Date;
   end: Date;
-  status: 'pending' | 'confirmed' | 'canceled';
+  status: ReservationStatus;
   place?: string;
+  people?: number;
+  nickname?: string;
 };


### PR DESCRIPTION
## PR 개요

- 카테고리 선택 버튼 추가

## 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링

## 상세 설명

- 공통 컴포넌트를 사용하기엔 이슈가 있어 보여 새로 구현 (`ExperienceSelect.tsx`)
- 드롭다운을 커스텀 하고 싶어 select 대신 button, ul, 등으로 커스텀 함
- width 는 full 로 조정 (달력, button 모두)
- '체험명' 이라는 타이틀이 button borer 위에 있어서 `absolute` 로 고정

## 관련 이슈

- closes #이슈번호

## Attachment

<img width="341" height="83" alt="image" src="https://github.com/user-attachments/assets/bf4a800a-6e59-44fb-ac82-5a041c46076c" />

<img width="1180" height="432" alt="image" src="https://github.com/user-attachments/assets/70287134-072c-4156-849e-28ac053c4c09" />
