### PR TITLE
feat: 헤더> 프로필 메뉴 선택 시, 내 정보 페이지로 이동

### DIFF
--- a/src/components/Header/Profile.tsx
+++ b/src/components/Header/Profile.tsx
@@ -1,25 +1,28 @@
 'use client';
-
+import { useRouter } from 'next/navigation';
 import ProfileImage from '../ProfileImage/ProfileImage';
 
 export interface ProfileProps {
   userName?: string;
   userImage?: string;
-  onClick?: () => void;
 }
 
-export default function Profile({
-  userName,
-  userImage,
-  onClick,
-}: ProfileProps) {
+export default function Profile({ userName, userImage }: ProfileProps) {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push('/Profile/MyInfo'); // 프로필 메뉴로 클릭 시, 내정보 페이지로 이동
+  };
+
   return (
-    <div className="flex items-center gap-2 cursor-pointer" onClick={onClick}>
+    <div
+      className="flex items-center gap-2 cursor-pointer"
+      onClick={handleClick}
+    >
       {/* 프로필 이미지 */}
       <div className="h-8 w-8 rounded-full overflow-hidden">
         <ProfileImage imageUrl={userImage} name={userName} />
       </div>
-
       {/* 이름 */}
       <span className="text-[#1B1B1B] hover:text-[#79747E] font-medium text-sm leading-6 tracking-normal text-center transition-colors duration-300 whitespace-nowrap">
         {userName}


### PR DESCRIPTION
## PR 개요

- 헤더> 로그인 후 노출되는 프로필 메뉴에 이동 경로 추가

## 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링

## 상세 설명

- 헤더> 로그인 상태에서 노출되는 프로필 메뉴 선택 시, /Profile/MyInfo 내 정보 페이지로 이동되게 기능 추가
  - useRouter 훅을 사용하여 클릭 이벤트 핸들러를 만듬
  - router.push('/Profile/MyInfo')를 호출 → 사용자가 프로필 영역을 클릭하면 /Profile/MyInfo 페이지로 이동

```
export default function Profile({ userName, userImage }: ProfileProps) {
  const router = useRouter();

  const handleClick = () => {
    router.push('/Profile/MyInfo'); // 프로필 메뉴로 클릭 시, 내정보 페이지로 이동
  };
```
## 관련 이슈

- closes #이슈번호

## Attachment

- 참고할 자료 첨부
