### PR TITLE
다음 주소 api 추가 + 모달 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react": "19.1.0",
         "react-big-calendar": "^1.19.4",
         "react-datepicker": "^8.7.0",
+        "react-daum-postcode": "^3.2.0",
         "react-dom": "19.1.0",
         "tailwind-merge": "^3.3.1",
         "tailwind-scrollbar-hide": "^4.0.0",
@@ -8130,6 +8131,15 @@
       "peerDependencies": {
         "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/react-daum-postcode": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.2.0.tgz",
+      "integrity": "sha512-NHY8TUicZXMqykbKYT8kUo2PEU7xu1DFsdRmyWJrLEUY93Xhd3rEdoJ7vFqrvs+Grl9wIm9Byxh3bI+eZxepMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-docgen": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "19.1.0",
     "react-big-calendar": "^1.19.4",
     "react-datepicker": "^8.7.0",
+    "react-daum-postcode": "^3.2.0",
     "react-dom": "19.1.0",
     "tailwind-merge": "^3.3.1",
     "tailwind-scrollbar-hide": "^4.0.0",

--- a/src/app/Profile/ExperienceAdd/page.tsx
+++ b/src/app/Profile/ExperienceAdd/page.tsx
@@ -1,20 +1,21 @@
 'use client';
 
 import 'react-datepicker/dist/react-datepicker.css';
-import { useState } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 
 import FormInput from '@/components/Input/CustomInput';
 import { useInputValue } from '@/hooks/useInputValue';
 import Dropdown from '@/components/Dropdown/Dropdown';
-import DatePicker from '@/components/datepicker/DatePicker';
-import StartTimePicker from '@/components/TimePicker/StartTimePicker';
-import EndTimePicker from '@/components/TimePicker/EndTimePicker';
 import MypageHeader from '@/app/Profile/_components/MypageHeader/MypageHeader';
-import Image from 'next/image';
+import ImageUploader from '@/app/Profile/_components/ImageUploader/ImageUploader';
+import DaumPostcode from 'react-daum-postcode';
+import TimeSlots, {
+  TimeSlot,
+} from '@/app/Profile/_components/TimeSlots/TimeSlots';
+import ConfirmModal from '@/components/Modal/ConfirmModal';
 
-export default function Experience() {
-  const [startDate, setStartDate] = useState<Date | null>(new Date());
-  const [form, handleChange] = useInputValue({
+export default function ExperienceAdd() {
+  const [form, setForm, handleChange] = useInputValue({
     title: '',
     category: '',
     content: '',
@@ -22,21 +23,59 @@ export default function Experience() {
     address: '',
     description: '',
   });
-  const dummyImages = [
-    '/images/street_dance.png',
-    '/images/street_dance.png',
-    '/images/street_dance.png',
-    '/images/street_dance.png',
-  ];
+
+  const [bannerImages, setBannerImages] = useState<string[]>([]);
+  const [introImages, setIntroImages] = useState<string[]>([]);
+  const [selectedSlots, setSelectedSlots] = useState<TimeSlot[]>([]);
+
+  const [isPostcodeOpen, setIsPostcodeOpen] = useState(false);
+  const handleAddressComplete = (data: { address: string }) => {
+    setForm((prev) => ({ ...prev, address: data.address }));
+    setIsPostcodeOpen(false);
+  };
+
+  const [dropdownCategory, setDropdownCategory] = useState('');
+  useEffect(() => {
+    if (dropdownCategory) {
+      setForm((prev) => ({ ...prev, category: dropdownCategory }));
+    }
+  }, [dropdownCategory, setForm]);
+
+  const isFormValid = useMemo(() => {
+    const { title, category, price, address, description } = form;
+
+    const baseValid =
+      title.trim() &&
+      category.trim() &&
+      price.trim() &&
+      address.trim() &&
+      description.trim();
+
+    const imagesValid = bannerImages.length > 0 && introImages.length > 0;
+    const timeValid = selectedSlots.length > 0;
+
+    return !!(baseValid && imagesValid && timeValid);
+  }, [form, bannerImages, introImages, selectedSlots]);
+
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isFormValid) return alert('모든 항목을 입력해주세요');
+    setIsConfirmOpen(true);
+  };
+
+  const categoryOptions = ['문화예술', '식음료', '스포츠', '투어', '관광'];
 
   return (
     <div className="w-[100%] lg:w-[792px]">
-      <form>
+      <form onSubmit={handleSubmit}>
         <MypageHeader
           title="내 체험 등록"
           type="button"
           buttonText="등록하기"
-          onClick={() => {}}
+          onClick={handleSubmit}
+          disabled={!isFormValid}
         />
         <FormInput
           id="title"
@@ -45,25 +84,22 @@ export default function Experience() {
           labelText=""
           placeholder="제목"
           value={form.title}
+          onChange={handleChange}
         />
-        <Dropdown>
-          <Dropdown.Button color="dropdownPrimary">카테고리</Dropdown.Button>
+        <Dropdown
+          onSelect={(value) =>
+            setForm((prev) => ({ ...prev, category: value }))
+          }
+        >
+          <Dropdown.Button color="dropdownPrimary">
+            {form.category || '카테고리'}
+          </Dropdown.Button>
           <Dropdown.Content color="dropdownPrimary">
-            <Dropdown.Item color="dropdownPrimary" value="문화예술">
-              문화예술
-            </Dropdown.Item>
-            <Dropdown.Item color="dropdownPrimary" value="식음료">
-              식음료
-            </Dropdown.Item>
-            <Dropdown.Item color="dropdownPrimary" value="스포츠">
-              스포츠
-            </Dropdown.Item>
-            <Dropdown.Item color="dropdownPrimary" value="투어">
-              투어
-            </Dropdown.Item>
-            <Dropdown.Item color="dropdownPrimary" value="관광">
-              관광
-            </Dropdown.Item>
+            {categoryOptions.map((item) => (
+              <Dropdown.Item key={item} color="dropdownPrimary" value={item}>
+                <>{item}</>
+              </Dropdown.Item>
+            ))}
           </Dropdown.Content>
         </Dropdown>
         <FormInput
@@ -73,144 +109,79 @@ export default function Experience() {
           labelText=""
           placeholder="설명"
           value={form.description}
+          onChange={handleChange}
         />
         <h1 className="text-xl font-bold mb-[16px] lg:text-2xl">가격</h1>
         <FormInput
-          id="title"
-          name="title"
+          id="price"
+          name="price"
           type="text"
           labelText=""
           placeholder="가격"
-          value={form.title}
+          value={form.price}
+          onChange={handleChange}
         />
         <h1 className="text-xl font-bold mb-[16px] lg:text-2xl">주소</h1>
-        <FormInput
-          id="title"
-          name="title"
-          type="text"
-          labelText=""
-          placeholder="주소를 입력해주세요"
-          value={form.title}
-        />
+        <div className="relative">
+          <FormInput
+            id="address"
+            name="address"
+            type="text"
+            labelText=""
+            placeholder="주소를 입력해주세요"
+            value={form.address}
+            onChange={handleChange}
+          />
+          <button
+            type="button"
+            onClick={() => setIsPostcodeOpen(true)}
+            className="absolute right-3 top-[50%] -translate-y-[50%] bg-gray-100 border border-gray-300 px-3 py-2 rounded-md text-sm hover:bg-gray-200 transition"
+          >
+            주소 검색
+          </button>
+        </div>
+
+        {isPostcodeOpen && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div className="bg-white p-5 rounded-xl shadow-lg w-[90%] max-w-[480px] relative">
+              <button
+                onClick={() => setIsPostcodeOpen(false)}
+                className="absolute top-2 right-3 text-gray-500 hover:text-black"
+              >
+                x
+              </button>
+              <DaumPostcode onComplete={handleAddressComplete} />
+            </div>
+          </div>
+        )}
 
         <h1 className="text-2xl font-bold mb-[16px]">예약 가능한 시간대</h1>
-        <div>
-          <ul className="flex">
-            <li className="w-[130px] md:w-[149px] lg:w-[379px] mr-[4px] pb-[8px] md:pb-[10px] lg:mr-[20px] lg:pb-[10px]">
-              <p className="text-lg text-[#4b4b4b] md:text-xl lg:text-xl">
-                날짜
-              </p>
-            </li>
-            <li className="w-[79px] md:w-[104px] lg:w-[140px] pb-[8px] lg:mr-[38px] lg:pb-[10px]">
-              <p className="text-lg text-[#4b4b4b] md:text-xl lg:text-xl">
-                시작 시간
-              </p>
-            </li>
-            <li></li>
-            <li className="w-[79px] md:w-[104px]lg:w-[140px] pb-[8px] lg:pb-[10px]">
-              <p className="text-lg text-[#4b4b4b] md:text-xl lg:text-xl">
-                종료 시간
-              </p>
-            </li>
-          </ul>
-          <ul className="flex">
-            <li className="w-[130px] md:w-[30%] lg:w-[379px] mr-[4px] lg:mr-[20px]">
-              <DatePicker className="w-[130px] lg:w-[379px]" />
-            </li>
-            <li className="w-[79px] md:w-[18%] lg:w-[140px]">
-              <StartTimePicker />
-            </li>
-            <li className="hidden lg:block px-[12px]">
-              <p className="leading-[56px]">~</p>
-            </li>
-            <li className="w-[79px] md:w-[18%] lg:w-[140px]">
-              <EndTimePicker />
-            </li>
-            <li className="w-[56px] h-[56px] relative ml-auto">
-              <Image
-                src="/icon/btn/plus_time.svg"
-                alt="로고"
-                fill
-                className=""
-              />
-            </li>
-          </ul>
-        </div>
-
-        <h1 className="text-xl font-bold mb-[16px] mt-[24px] lg:text-2xl">
-          배너 이미지
-        </h1>
-        <div>
-          <ul className="overflow-hidden">
-            <li className="relative aspect-square w-[49%] float-left mb-[8px] lg:w-[180px] lg:mr-[24px] lg:mb-[24px]">
-              <Image
-                src="/icon/btn/img.svg"
-                alt="로고"
-                fill
-                className="object-cover"
-              />
-            </li>
-
-            {dummyImages.map((src, idx) => {
-              const position = idx + 2;
-              const isLastInRow = position % 4 === 0;
-              const isEven = position % 2 === 0;
-
-              return (
-                <li
-                  key={idx}
-                  className={`relative aspect-square w-[49%] mb-[8px] lg:w-[180px] lg:mb-[24px] rounded-3xl overflow-hidden float-left ${
-                    isEven ? 'float-right lg:float-left' : 'float-left'
-                  } ${isLastInRow ? 'mr-0 mb-0' : 'lg:mr-[24px]'}`}
-                >
-                  <Image
-                    src={src}
-                    alt={`이미지-${idx}`}
-                    fill
-                    className="object-cover"
-                  />
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-        <h1 className="text-xl font-bold mb-[16px] lg:text-2xl">소개 이미지</h1>
-        <div>
-          <ul className="overflow-hidden">
-            <li className="relative aspect-square w-[49%] float-left mb-[8px] lg:w-[180px] lg:mr-[24px] lg:mb-[24px]">
-              <Image
-                src="/icon/btn/img.svg"
-                alt="로고"
-                fill
-                className="object-cover"
-              />
-            </li>
-
-            {dummyImages.map((src, idx) => {
-              const position = idx + 2;
-              const isLastInRow = position % 4 === 0;
-              const isEven = position % 2 === 0;
-
-              return (
-                <li
-                  key={idx}
-                  className={`relative aspect-square w-[49%] mb-[8px] lg:w-[180px] lg:mb-[24px] rounded-3xl overflow-hidden float-left ${
-                    isEven ? 'float-right lg:float-left' : 'float-left'
-                  } ${isLastInRow ? 'mr-0 mb-0' : 'lg:mr-[24px]'}`}
-                >
-                  <Image
-                    src={src}
-                    alt={`이미지-${idx}`}
-                    fill
-                    className="object-cover"
-                  />
-                </li>
-              );
-            })}
-          </ul>
-        </div>
+        <TimeSlots
+          selectedSlots={selectedSlots}
+          setSelectedSlots={setSelectedSlots}
+        />
+        <ImageUploader
+          title="배너이미지"
+          images={bannerImages}
+          setImages={setBannerImages}
+        />
+        <ImageUploader
+          title="소개이미지"
+          images={introImages}
+          setImages={setIntroImages}
+        />
         <p>이미지는 최대 4개까지 등록 가능합니다.</p>
       </form>
+
+      <ConfirmModal
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        message="체험 등록이 완료되었습니다"
+        className="bg-white"
+        onConfirm={() => {
+          setIsConfirmOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/src/app/Profile/ExperienceSet/page.tsx
+++ b/src/app/Profile/ExperienceSet/page.tsx
@@ -1,17 +1,24 @@
 'use client';
 
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Dropdown from '@/components/Dropdown/Dropdown';
 import MypageHeader from '@/app/Profile/_components/MypageHeader/MypageHeader';
 import Image from 'next/image';
+import ConfirmModal from '@/components/Modal/ConfirmModal';
 
 export default function Experience() {
+  const router = useRouter();
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [selectedItem, setSelectedItem] = useState<string | null>(null);
+
   return (
     <div className="w-[100%] md:pl-[16px] lg:w-[800px]">
       <MypageHeader
         title="내 체험 관리"
         type="button"
         buttonText="체험 등록하기"
-        onClick={() => {}}
+        onClick={() => router.push('/Profile/ExperienceAdd')}
       />
       <div>
         <ul className="bg-white rounded-3xl flex shadow-xl mb-[24px]">
@@ -39,7 +46,11 @@ export default function Experience() {
             <div>
               <p className="float-left leading-[40px]">\10,000 / 인</p>
               <div className="float-right">
-                <Dropdown>
+                <Dropdown
+                  onSelect={(value) => {
+                    if (value === '삭제하기') setIsDeleteModalOpen(true);
+                  }}
+                >
                   <Dropdown.Button color="dropdownSet">
                     <div>
                       <Image
@@ -66,6 +77,17 @@ export default function Experience() {
           </li>
         </ul>
       </div>
+      <ConfirmModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        message="삭제가 완료되었습니다."
+        confirmLabel="확인"
+        className="bg-white"
+        onConfirm={() => {
+          console.log('삭제 실행:', selectedItem);
+          setIsDeleteModalOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/src/app/Profile/_components/ImageUploader/ImageUploader.tsx
+++ b/src/app/Profile/_components/ImageUploader/ImageUploader.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import Image from 'next/image';
+import { useRef } from 'react';
+
+type ImageUploaderProps = {
+  title: string;
+  images: string[];
+  setImages: React.Dispatch<React.SetStateAction<string[]>>;
+  maxCount?: number;
+};
+
+export default function ImageUploader({
+  title,
+  images,
+  setImages,
+  maxCount = 4,
+}: ImageUploaderProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleClick = () => fileInputRef.current?.click();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    if (images.length + files.length > maxCount) {
+      alert(`${title}는 최대 ${maxCount}개까지만 업로드 가능합니다.`);
+      return;
+    }
+    const newImages = Array.from(files).map((file) =>
+      URL.createObjectURL(file)
+    );
+    setImages((prev) => [...prev, ...newImages].slice(0, maxCount));
+  };
+
+  return (
+    <div className="mt-[24px]">
+      <h1 className="text-xl font-bold mb-[16px] lg:text-2xl">{title}</h1>
+      <input
+        type="file"
+        accept="image/*"
+        multiple
+        ref={fileInputRef}
+        onChange={handleChange}
+        className="hidden"
+      />
+      <ul className="overflow-hidden">
+        <li
+          className="relative aspect-square w-[49%] float-left mb-[8px] lg:w-[180px] lg:mr-[24px] lg:mb-[24px] cursor-pointer"
+          onClick={handleClick}
+        >
+          <Image
+            src="/icon/btn/img.svg"
+            alt="이미지추가"
+            fill
+            className="object-cover"
+          />
+        </li>
+        {images.map((src, idx) => (
+          <li
+            key={idx}
+            className={`relative aspect-square w-[49%] mb-[8px] lg:w-[180px] lg:mb-[24px] rounded-3xl overflow-hidden float-left ${
+              idx % 3 === 2 ? 'lg:mr-0' : 'lg:mr-[24px]'
+            }`}
+          >
+            <Image
+              src={src}
+              alt={`${title}-${idx}`}
+              fill
+              className="object-cover"
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/Profile/_components/MypageHeader/MypageHeader.tsx
+++ b/src/app/Profile/_components/MypageHeader/MypageHeader.tsx
@@ -9,6 +9,7 @@ type HeaderType = {
   selected?: string;
   setSelected?: React.Dispatch<React.SetStateAction<string>>;
   selectList?: string[];
+  disabled?: boolean;
 };
 export default function MypageHeader({
   title,
@@ -18,6 +19,7 @@ export default function MypageHeader({
   selected,
   setSelected,
   selectList,
+  disabled = false,
 }: HeaderType) {
   return (
     <div
@@ -32,7 +34,11 @@ export default function MypageHeader({
         <Button
           color="buttonPrimary"
           onClick={onClick ?? (() => {})}
-          className="h-12 px-8 rounded-sm"
+          disabled={disabled}
+          className={clsx(
+            'h-12 px-8 rounded-sm',
+            disabled && 'cursor-not-allowed'
+          )}
         >
           {buttonText}
         </Button>

--- a/src/app/Profile/_components/TimeSlots/TimeSlots.tsx
+++ b/src/app/Profile/_components/TimeSlots/TimeSlots.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import DatePickerComponent from '@/components/datepicker/DatePicker';
+import StartTimePicker from '@/components/TimePicker/StartTimePicker';
+import EndTimePicker from '@/components/TimePicker/EndTimePicker';
+
+export interface TimeSlot {
+  id: number;
+  date: Date | null;
+  startTime: Date | null;
+  endTime: Date | null;
+}
+
+interface TimeSlotsProps {
+  selectedSlots: TimeSlot[];
+  setSelectedSlots: React.Dispatch<React.SetStateAction<TimeSlot[]>>;
+  onChange?: (slots: TimeSlot[]) => void;
+}
+
+export default function TimeSlots({
+  selectedSlots,
+  setSelectedSlots,
+  onChange,
+}: TimeSlotsProps) {
+  const [newSlot, setNewSlot] = useState<TimeSlot>({
+    id: 0,
+    date: null,
+    startTime: null,
+    endTime: null,
+  });
+
+  const handleAddTimeSlot = () => {
+    if (!newSlot.date || !newSlot.startTime || !newSlot.endTime) return;
+    const slotToAdd = { ...newSlot, id: Date.now() };
+    const updatedSlots = [...selectedSlots, slotToAdd];
+    setSelectedSlots(updatedSlots);
+    onChange?.(updatedSlots);
+
+    setNewSlot({ id: 0, date: null, startTime: null, endTime: null });
+  };
+
+  const handleDeleteTimeSlot = (id: number) => {
+    const updatedSlots = selectedSlots.filter((slot) => slot.id !== id);
+    setSelectedSlots(updatedSlots);
+    onChange?.(updatedSlots);
+  };
+
+  return (
+    <div>
+      <ul className="flex mb-2">
+        <li className="w-[130px] md:w-[149px] lg:w-[379px] mr-[4px] lg:mr-[20px]">
+          <p className="text-lg text-[#4b4b4b] md:text-xl">날짜</p>
+        </li>
+        <li className="w-[79px] md:w-[104px] lg:w-[140px] mr-[38px]">
+          <p className="text-lg text-[#4b4b4b] md:text-xl">시작 시간</p>
+        </li>
+        <li className="hidden lg:block px-[12px]" />
+        <li className="w-[79px] md:w-[104px] lg:w-[140px]">
+          <p className="text-lg text-[#4b4b4b] md:text-xl">종료 시간</p>
+        </li>
+      </ul>
+
+      <ul className="flex mb-4 items-center">
+        <li className="w-[130px] md:w-[30%] lg:w-[379px] mr-[4px] lg:mr-[20px]">
+          <DatePickerComponent
+            className="w-[130px] lg:w-[379px]"
+            selected={newSlot.date ?? undefined}
+            onChange={(date: Date | null) =>
+              setNewSlot((prev) => ({ ...prev, date }))
+            }
+          />
+        </li>
+
+        <li className="w-[79px] md:w-[18%] lg:w-[140px]">
+          <StartTimePicker
+            className="w-[79px] lg:w-[140px]"
+            value={newSlot.startTime}
+            onChange={(time) =>
+              setNewSlot((prev) => ({ ...prev, startTime: time }))
+            }
+          />
+        </li>
+
+        <li className="hidden lg:block px-[12px]">
+          <p className="leading-[56px]">~</p>
+        </li>
+
+        <li className="w-[79px] md:w-[18%] lg:w-[140px]">
+          <EndTimePicker
+            className="w-[79px] lg:w-[140px]"
+            value={newSlot.endTime}
+            onChange={(time) =>
+              setNewSlot((prev) => ({ ...prev, endTime: time }))
+            }
+          />
+        </li>
+
+        <li
+          className="w-[56px] h-[56px] relative ml-auto cursor-pointer"
+          onClick={handleAddTimeSlot}
+        >
+          <Image src="/icon/btn/plus_time.svg" alt="추가" fill />
+        </li>
+      </ul>
+
+      {selectedSlots.map((slot) => (
+        <ul key={slot.id} className="flex mb-3 items-center">
+          <li className="w-[130px] md:w-[30%] lg:w-[379px] mr-[4px] lg:mr-[20px] py-[15px] px-[16px] border rounded-sm">
+            <p>
+              {slot.date
+                ? `${slot.date.getFullYear().toString().slice(2)}/${(
+                    slot.date.getMonth() + 1
+                  )
+                    .toString()
+                    .padStart(2, '0')}/${slot.date
+                    .getDate()
+                    .toString()
+                    .padStart(2, '0')}`
+                : '-'}
+            </p>
+          </li>
+
+          <li className="w-[79px] md:w-[18%] lg:w-[140px] py-[15px] border rounded-sm">
+            <p>
+              {slot.startTime?.toLocaleTimeString([], {
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: false,
+              })}
+            </p>
+          </li>
+
+          <li className="hidden lg:block px-[12px]">
+            <p className="leading-[56px]">~</p>
+          </li>
+
+          <li className="w-[79px] md:w-[18%] lg:w-[140px] py-[15px] border rounded-sm">
+            <p>
+              {slot.endTime?.toLocaleTimeString([], {
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: false,
+              })}
+            </p>
+          </li>
+
+          <li
+            className="w-[56px] h-[56px] relative ml-auto cursor-pointer"
+            onClick={() => handleDeleteTimeSlot(slot.id)}
+          >
+            <Image src="/icon/btn/minus_time.svg" alt="삭제" fill />
+          </li>
+        </ul>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -13,18 +13,21 @@ const DropdownContext = React.createContext<{
   setOpen: (open: boolean) => void;
   selected: string;
   setSelected: (val: string) => void;
+  onSelect?: (value: string) => void;
 }>({
   open: false,
   setOpen: () => {},
   selected: '',
   setSelected: () => {},
+  onSelect: undefined,
 });
 
 interface DropdownProps {
   children: ReactNode;
+  onSelect?: (value: string) => void;
 }
 
-export default function Dropdown({ children }: DropdownProps) {
+export default function Dropdown({ children, onSelect }: DropdownProps) {
   const [open, setOpen] = useState(false);
   const [selected, setSelected] = useState('');
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -43,7 +46,9 @@ export default function Dropdown({ children }: DropdownProps) {
   }, [open]);
 
   return (
-    <DropdownContext.Provider value={{ open, setOpen, selected, setSelected }}>
+    <DropdownContext.Provider
+      value={{ open, setOpen, selected, setSelected, onSelect }}
+    >
       <div ref={dropdownRef} className="relative">
         {children}
       </div>
@@ -176,12 +181,13 @@ function DropdownItem({
   children,
   color = 'dropdownPrimary',
 }: DropdownItemProps) {
-  const { setSelected, setOpen } = useContext(DropdownContext);
+  const { setSelected, setOpen, onSelect } = useContext(DropdownContext);
 
   const handleClick = () => {
     if (color === 'dropdownPrimary') {
       setSelected(value);
     }
+    onSelect?.(value);
     setOpen(false);
   };
 

--- a/src/components/TimePicker/EndTimePicker.tsx
+++ b/src/components/TimePicker/EndTimePicker.tsx
@@ -1,18 +1,21 @@
 'use client';
 
 import clsx from 'clsx';
-import React, { useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import './TimePicker.css';
 
-type DatePickerType = {
+type EndTimePickerProps = {
   className?: string;
+  value: Date | null;
+  onChange: (date: Date | null) => void;
 };
-export default function EndTimePicker({ className }: DatePickerType) {
-  const [endTime, setEndTime] = useState<Date | null>(
-    new Date(new Date().getTime() + 15 * 60000) // 시작 기준 +15분
-  );
+export default function EndTimePicker({
+  className,
+  value,
+  onChange,
+}: EndTimePickerProps) {
   const endRef = useRef<DatePicker | null>(null);
 
   const handleEndClick = () => endRef.current?.setOpen(true);
@@ -21,14 +24,14 @@ export default function EndTimePicker({ className }: DatePickerType) {
     <div className="relative">
       <DatePicker
         ref={endRef}
-        selected={endTime}
-        onChange={(date: Date | null) => setEndTime(date)}
+        selected={value}
+        onChange={onChange}
         showTimeSelect
         showTimeSelectOnly
         timeIntervals={15}
         timeCaption="시간"
         dateFormat="HH:mm"
-        placeholderText="종료 시간"
+        placeholderText="0:00"
         className={clsx(
           className,
           'border px-3 py-2 rounded w-[80px] text-center cursor-pointer text-md',

--- a/src/components/TimePicker/StartTimePicker.tsx
+++ b/src/components/TimePicker/StartTimePicker.tsx
@@ -1,16 +1,21 @@
 'use client';
 
 import clsx from 'clsx';
-import React, { useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import './TimePicker.css';
 
-type DatePickerType = {
+type StartTimePickerProps = {
   className?: string;
+  value: Date | null;
+  onChange: (date: Date | null) => void;
 };
-export default function StartTimePicker({ className }: DatePickerType) {
-  const [startTime, setStartTime] = useState<Date | null>(new Date());
+export default function StartTimePicker({
+  className,
+  value,
+  onChange,
+}: StartTimePickerProps) {
   const startRef = useRef<DatePicker | null>(null);
 
   const handleStartClick = () => startRef.current?.setOpen(true);
@@ -19,14 +24,14 @@ export default function StartTimePicker({ className }: DatePickerType) {
     <div className="relative">
       <DatePicker
         ref={startRef}
-        selected={startTime}
-        onChange={(date: Date | null) => setStartTime(date)}
+        selected={value}
+        onChange={onChange}
         showTimeSelect
         showTimeSelectOnly
         timeIntervals={15}
         timeCaption="시간"
         dateFormat="HH:mm"
-        placeholderText="시작 시간"
+        placeholderText="0:00"
         className={clsx(
           className,
           'border px-3 py-2 rounded w-[80px] text-center cursor-pointer text-md',

--- a/src/components/datepicker/DatePicker.tsx
+++ b/src/components/datepicker/DatePicker.tsx
@@ -9,8 +9,14 @@ import './datePicker.css';
 
 type DatePickerType = {
   className?: string;
+  selected?: Date | null;
+  onChange?: (date: Date | null) => void;
 };
-export default function DatePickerComponent({ className }: DatePickerType) {
+export default function DatePickerComponent({
+  className,
+  selected,
+  onChange,
+}: DatePickerType) {
   const [startDate, setStartDate] = useState<Date | null>(new Date());
   const datePickerRef = useRef<DatePicker>(null);
   const handleDatePickerClick = () => {
@@ -23,8 +29,8 @@ export default function DatePickerComponent({ className }: DatePickerType) {
     <div className="relative w-fit rounded-sm border border-gray-700">
       <DatePicker
         ref={datePickerRef}
-        selected={startDate}
-        onChange={(date) => setStartDate(date)}
+        selected={selected}
+        onChange={onChange}
         placeholderText="YY/MM/DD"
         className={clsx(
           className,


### PR DESCRIPTION
## PR 개요

- 페이지 이동, 모달 추가, 다음 주소 api 연결

## 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링

## 상세 설명

- 내 체험 관리에서 '체험 등록하기' 버튼 누르면 등록 페이지로 이동
- 내 체험 관리에서 '삭제하기' 버튼 눌렀을때 모달 추가
- 내 체험 등록에서 다음 주소 API 연결 (package.json에 'react-daum-postcode' 추가됨)
- 내 체험 등록에서 time, image 부분 컴포넌트로 분리
- 내 체험 등록에서 상단 '등록하기' 버튼 비활성화, 모든 항목 입력시 활성화

## 관련 이슈

- closes #이슈번호

## Attachment

<img width="837" height="660" alt="스크린샷 2025-10-20 오전 4 03 22" src="https://github.com/user-attachments/assets/f014c79e-19f9-4978-99a7-52e9b156956e" />
<img width="528" height="508" alt="스크린샷 2025-10-20 오전 4 11 46" src="https://github.com/user-attachments/assets/fd227547-1298-4b61-aecd-b1926636183d" />
<img width="1215" height="809" alt="스크린샷 2025-10-20 오전 4 07 40" src="https://github.com/user-attachments/assets/6909fd08-8fe5-4d76-a46c-16c5e45c1c84" />
<img width="1221" height="782" alt="스크린샷 2025-10-20 오전 4 07 31" src="https://github.com/user-attachments/assets/3e73d357-ed27-443f-8858-e5439dfcbe96" />
