### PR TITLE
fix: 프로필 카드 로그아웃 글자 크기 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8883,7 +8883,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.2.tgz",
       "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",

--- a/src/components/Profile/ProfileCard.tsx
+++ b/src/components/Profile/ProfileCard.tsx
@@ -58,7 +58,7 @@ export default function ProfileCard() {
               <form
                 key={item.key}
                 action={logoutAction}
-                className="flex items-center gap-3 rounded-xl px-4 py-3 text-sm text-[var(--color-gray-400)] font-semibold cursor-pointer hover:bg-[var(--color-gray-100)] transition-colors"
+                className="flex items-center gap-3 rounded-xl px-4 py-3 text-[var(--color-gray-400)] font-semibold cursor-pointer hover:bg-[var(--color-gray-100)] transition-colors"
               >
                 <button
                   type="submit"


### PR DESCRIPTION
## PR 개요

- 프로필 카드 로그아웃 글자 크기 수정

## 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링

## Attachment
<img width="437" height="532" alt="image" src="https://github.com/user-attachments/assets/d66fa574-d66e-4b1f-8b2f-8074df45570e" />

