### PR TITLE
fix: CustomInput 타입 수정

### DIFF
--- a/src/components/Input/CustomInput.tsx
+++ b/src/components/Input/CustomInput.tsx
@@ -50,7 +50,8 @@ export default function CustomInput({
           name={name}
           placeholder={placeholder}
           value={value as string}
-          onChange={onChange as (e: ChangeEvent<HTMLTextAreaElement>) => void}
+          onChange={onChange} // 수정
+          // onChange={onChange as (e: ChangeEvent<HTMLTextAreaElement>) => void}
           className={`w-full px-5 py-4 rounded-md border
             border-gray-700 focus:outline-none
             min-h-[240px]
@@ -64,7 +65,8 @@ export default function CustomInput({
           type={type}
           placeholder={placeholder}
           value={value}
-          onChange={onChange as (e: ChangeEvent<HTMLInputElement>) => void}
+          onChange={onChange} // 수정
+          // onChange={onChange as (e: ChangeEvent<HTMLInputElement>) => void}
           className={`w-full px-5 py-4 rounded-md border
             border-gray-700 focus:outline-none
             text-lg text-black placeholder-gray-600

--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -63,6 +63,7 @@ export default function BaseModal({
   if (variant === 'dropdown') {
     return (
       <div
+        ref={overlayRef}
         role="dialog"
         aria-modal="true"
         className={[
@@ -70,7 +71,8 @@ export default function BaseModal({
           'rounded-lg shadow-xl',
           'max-h-[400px] overflow-auto z-[9999] w-[330px]',
         ].join(' ')}
-        onClick={(e) => e.stopPropagation()}
+        onClick={handleOverLayClick}
+        // onClick={(e) => e.stopPropagation()}
       >
         {title && (
           <div className="flex items-center justify-between px-6 py-4">

--- a/src/hooks/useInputValue.ts
+++ b/src/hooks/useInputValue.ts
@@ -4,7 +4,9 @@ import { ChangeEvent, useState } from 'react';
 export function useInputValue<T extends Record<string, string>>(initial: T) {
   const [input, setInput] = useState(initial);
 
-  function handleInputChange(e: ChangeEvent<HTMLInputElement>) {
+  function handleInputChange(
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement> // 수정 HTMLTextAreaElement 추가
+  ) {
     const { name, value } = e.target;
     setInput((prev) => ({
       ...prev,

--- a/src/hooks/useReservationsDashboard.ts
+++ b/src/hooks/useReservationsDashboard.ts
@@ -61,7 +61,7 @@ export default function useReservationsDashboard() {
     const fetchMyActivities = async () => {
       try {
         setIsLoadingActivities(true);
-        const response = await getMyActivities({});
+        const response = await getMyActivities();
         setMyActivities(response.activities);
         // 체험 목록을 불러온 후 첫번째 체험을 자동으로 선택
         if (response.activities.length > 0) {

--- a/src/lib/myactivities/api.ts
+++ b/src/lib/myactivities/api.ts
@@ -11,24 +11,24 @@ import {
 /**
  * 내 체험 목록
  */
-export async function getMyActivities(opts: {
-  cursorId?: number;
-  size?: number;
-}): Promise<MyActivitiesResponse> {
-  const { cursorId, size = 20 } = opts;
+export async function getMyActivities(
+  cursorId?: number,
+  size?: number
+): Promise<MyActivitiesResponse> {
+  // const { cursorId, size = 20 } = opts;
 
-  const queryString =
-    cursorId != null ? `cursorId=${cursorId}&size=${size}` : `size=${size}`;
+  const queryString = cursorId
+    ? `cursorId=${cursorId}&size=${size}`
+    : `size=${size}`;
 
-  const url = `/api/myactivities?${queryString}`;
-  const res = await fetch(url, {
+  const response = await fetch(`/api/myactivities?${queryString}`, {
     method: 'GET',
     cache: 'no-store',
   });
 
-  if (!res.ok) throw new Error('내 체험 목록을 불러오는 데 실패했습니다.');
+  if (!response.ok) throw new Error('내 체험 목록을 불러오는 데 실패했습니다.');
 
-  const data = await res.json();
+  const data = await response.json();
   return data;
 }
 

--- a/src/lib/mynotifications/api.ts
+++ b/src/lib/mynotifications/api.ts
@@ -1,5 +1,3 @@
-import { BASE_URL } from '@/lib/constants';
-import { apiFetch } from '@/lib/auth/apiFetch';
 import {
   type NotificationList,
   type DeleteNotificationRes,


### PR DESCRIPTION
## PR 개요

- fix: CustomInput 타입 수정

## 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링

## 상세 설명

1. `app/page.tsx` - `InputForm` 과의 타입 불일치 에러
> (type '(e: ChangeEvent<HTMLInputElement>) => void' is not assignable to type '(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void'.Types of parameters 'e' and 'e' are incompatible.Type 'ChangeEvent<HTMLInputElement | HTMLTextAreaElement>' is not assignable to type 'ChangeEvent<HTMLInputElement>'.Type 'HTMLInputElement | HTMLTextAreaElement' is not assignable to type 'HTMLInputElement'.Type 'HTMLTextAreaElement' is missing the following properties from type 'HTMLInputElement': accept, align, alt, capture, and 29 more.ts(2322)
CustomInput.tsx(14, 3): The expected type comes from property 'onChange' which is declared here on type 'IntrinsicAttributes & CustomInputProps')

2. `CustomInput` 컴포넌트가 `HTMLInputElement`만 받도록 정의되어 있는데, `page`에서 `HTMLInputElement | HTMLTextAreaElement` 둘 다 가능한 타입을 전달하려고 해서 발생

3. `CustomInput ` 타입을 넓게 수정해서 모두 사용할 수 있도록 함

<img width="723" height="359" alt="image" src="https://github.com/user-attachments/assets/732e9e7e-256b-4e4c-98f4-5c52f55dc249" />

4. 동일 오류 발생 -> `useInputValue` 훅에서도 하나만 받도록 되어있어 넓게 정의함

<img width="1522" height="366" alt="image" src="https://github.com/user-attachments/assets/e8fc947c-0b11-4b17-8c66-c104b3567b3e" />

## 관련 이슈

- closes #이슈번호

## Attachment

- 참고할 자료 첨부
